### PR TITLE
:beetle: Restore GetChildEntity for GenericPairEntityList.

### DIFF
--- a/Assets/Scripts/Data/Entity/GenericEntity.cs
+++ b/Assets/Scripts/Data/Entity/GenericEntity.cs
@@ -142,7 +142,7 @@ namespace CAFU.Generics.Data.Entity
     }
 
     [PublicAPI]
-    public class GenericPairEntityList<TGenericPairEntity> : GenericEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity
+    public class GenericPairEntityList<TGenericPairEntity> : GenericEntityList<TGenericPairEntity>, IGenericPairEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity
     {
     }
 


### PR DESCRIPTION
`GetChildEntity(TKey)` is missing at GenericPairEntityList class.